### PR TITLE
fix: ability to use of `config.rasi` display-* property

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -21,7 +21,6 @@ unsafe impl Sync for Api<'_> {}
 
 impl Api<'_> {
     pub(crate) unsafe fn new(display_name: ptr::NonNull<*mut u8>) -> Self {
-        assert_eq!(*unsafe { display_name.as_ref() }, ptr::null_mut());
         Self {
             display_name,
             display_name_len: 0,


### PR DESCRIPTION
Hi, your crate, looks and smells awesome. Thanks for developing it. I came with a proposal:

The Rofi users may want to configure their plugin's display_name via `~/.config/rofi/config.rasi`:

```
configuration {
   display-xplugin: "ICON XPLUGIN";
}
```

here, the `xplugin` is the display_name of the plugin. By changing display via configuration, causes whole library to panic. Here, complete RUST_BACKTRACE of [my plugin (WIP)](https://github.com/atahabaki/rofi-wifi-menu):

```
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
  left: `0x56409ec28990`,
 right: `0x0`', /home/atahabaki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rofi-mode-0.3.0/src/api.rs:36:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
   1: core::panicking::panic_fmt
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:228:5
   4: rofi_mode::api::Api::new
             at /home/atahabaki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rofi-mode-0.3.0/src/api.rs:36:9
   5: rofi_mode::init
             at /home/atahabaki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rofi-mode-0.3.0/src/lib.rs:288:28
   6: <unknown>
   7: <unknown>
   8: g_main_context_dispatch
   9: <unknown>
  10: g_main_loop_run
  11: main
  12: <unknown>
  13: __libc_start_main
  14: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5
```

I'm sorry, if I made a mistake. I could not see a reason to check the nullity of display_name. Furthermore, my plugin works great with these changes, no panicking at all.