### PR TITLE
fix: segfault that occurs when using a `rofi` theme that does not include an input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,8 +380,13 @@ unsafe extern "C" fn result<T: GivesMode>(
 
         let input: &mut *mut c_char = unsafe { &mut *input };
         let input_ptr: *mut c_char = mem::replace(&mut *input, ptr::null_mut());
-        let len = unsafe { libc::strlen(input_ptr) };
-        let mut input_string = unsafe { String::from_raw_parts(input_ptr.cast(), len, len + 1) };
+
+        let mut input_string = if input_ptr.is_null() {
+            String::new()
+        } else {
+            let len = unsafe { libc::strlen(input_ptr) };
+            unsafe { String::from_raw_parts(input_ptr.cast(), len, len + 1) }
+        };
 
         let action = mode.react(event, &mut input_string);
 


### PR DESCRIPTION
Someone using one of my plugins was running into a problem [here](https://github.com/Rolv-Apneseth/lib_game_detector/issues/5#issuecomment-1962782431). I managed to re-create the segfault by using a theme without an input entry like theirs, and this change fixes it.

Here is a minimal theme that causes the issue when run with a plugin using this library:

```
mainbox {
    enabled:                     true;
    children:                    [listview];
}
```

I have little knowledge about C and low-level programming in general so let me know if this has any potential side-effects or doesn't work how I imagine.

As for that first issue they were having, any ideas?

```
thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rofi-mode-0.3.1/src/api.rs:182:64:
called `Result::unwrap()` on an `Err` value: InvalidSize`
```