### PR TITLE
chore: update depedencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rofi-mode"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.60.0"
 description = "High-level library for creating Rofi plugins and custom modes"
@@ -10,11 +10,11 @@ keywords = ["rofi", "mode", "plugin"]
 categories = ["api-bindings"]
 
 [dependencies]
-bitflags = "2.2.1"
-cairo-rs = "0.19.2"
-libc = "0.2.142"
-pango = "0.19.2"
-rofi-plugin-sys = "0.5.0"
+bitflags = "2.9.1"
+cairo-rs = "0.21.0"
+libc = "0.2.174"
+pango = "0.21.0"
+rofi-plugin-sys = "0.5.1"
 
 [workspace]
 members = ["dev", "examples/*"]


### PR DESCRIPTION
In relation to SabrinaJewson/rofi-plugin-sys.rs#4, updating dependencies to resolve `glib` vulnerability warning.